### PR TITLE
fix: request data in markdown by default

### DIFF
--- a/nodes/Decodo/services/scraper-api-service.ts
+++ b/nodes/Decodo/services/scraper-api-service.ts
@@ -14,6 +14,11 @@ export class ScraperApiService {
     token: CredentialInformation;
     params: object;
   }) {
+    const body = {
+      ...params,
+      markdown: true,
+    };
+
     const resBody = await n8n.helpers.httpRequestWithAuthentication.call(n8n, creds, {
       url: this.SERVICE_URL_PROD,
       method: 'POST',
@@ -23,7 +28,7 @@ export class ScraperApiService {
         'Content-Type': 'application/json',
         'x-integration': 'n8n',
       },
-      body: params,
+      body,
     });
 
     return resBody;


### PR DESCRIPTION
In this MR:
- Add `markdown: true` to every request to reduce token count.